### PR TITLE
Clear namedBlocks after each template is compiled

### DIFF
--- a/Nextras/Latte/Macros/RedefineMacro.php
+++ b/Nextras/Latte/Macros/RedefineMacro.php
@@ -93,6 +93,7 @@ class RedefineMacro extends MacroSet
 			}
 			$prolog[] = "//\n// end of blocks\n//";
 		}
+		$this->namedBlocks = array();
 
 		return array(implode("\n\n", $prolog), "");
 	}


### PR DESCRIPTION
I have multiple templates with (re)defined block which are included to each other (eg. common.latte with some blocks that are same for more templates). 

Currently all redefined blocks was complied to every template - eg. if foo.latte redefined block "foo" and included comon.latte, compiled common.latte also contained code for block "foo". 

This pull clears blocks array after each template is finalized, which fix the issue. 
