### PR TITLE
Fix RedefineMacro when no blocks are defined

### DIFF
--- a/src/RedefineMacro.php
+++ b/src/RedefineMacro.php
@@ -44,8 +44,16 @@ class RedefineMacro extends BlockMacros
 
 		list($prolog) = parent::finalize();
 
-		foreach ($compiler->getProperties()['blocks'] as $key => $val) { $blocks[$key] = $val; }
-		foreach ($compiler->getProperties()['blockTypes'] as $key => $val) { $blockTypes[$key] = $val; }
+		if (isset($compiler->getProperties()['blocks'])) {
+			foreach ($compiler->getProperties()['blocks'] as $key => $val) {
+				$blocks[$key] = $val;
+			}
+		}
+		if (isset($compiler->getProperties()['blockTypes'])) {
+			foreach ($compiler->getProperties()['blockTypes'] as $key => $val) {
+				$blockTypes[$key] = $val;
+			}
+		}
 		$compiler->addProperty('blocks', $blocks);
 		$compiler->addProperty('blockTypes', $blockTypes);
 

--- a/tests/RedefineMacroTests.phpt
+++ b/tests/RedefineMacroTests.phpt
@@ -27,3 +27,4 @@ Assert::same('import.latte', render('case1/main.latte'));
 Assert::same('main.latte', render('case2/main.latte'));
 Assert::same('import.latte', render('case3/main.latte'));
 Assert::same('import.latte', render('case4/main.latte'));
+Assert::same('No blocks', render('case5/main.latte'));

--- a/tests/case5/main.latte
+++ b/tests/case5/main.latte
@@ -1,0 +1,1 @@
+No blocks


### PR DESCRIPTION
Hi, there was a notice *Undefined index: blocks* in cases when template does not contains any blocks. This pull request fixes it. 